### PR TITLE
add dedicated flags for outptting GDV compatible scripts

### DIFF
--- a/src/main/scala/leo/Configuration.scala
+++ b/src/main/scala/leo/Configuration.scala
@@ -55,6 +55,7 @@ object Configuration extends DefaultConfiguration {
   private val PARAM_PASSTOEMBEDDING = "embedding-param"
   private val PARAM_LPOUTPUTPATH = "lp-output"
   private val PARAM_GDV_LP = "gdv-lp"
+  private val PARAM_SKOLEMIZE = "skolemize"
 
   // Collect standard options for nice output: short-option -> (long option, argname, description)
   private val optionsMap : Map[Char, (String, String, String)] = {
@@ -83,6 +84,7 @@ object Configuration extends DefaultConfiguration {
       PROBLEMFILE
       PROOF_OBJECT
       LP_PROOF_OBJECT
+      SKOLEMIZE
       VERBOSITY
       LPDEBUG
       SOS
@@ -150,6 +152,7 @@ object Configuration extends DefaultConfiguration {
 
   lazy val PROOF_OBJECT : Boolean = isSet(PARAM_PROOFOBJECT) && !isSet(PARAM_GDV_LP)
   lazy val LP_PROOF_OBJECT : Boolean = isSet(PARAM_GDV_LP)
+  lazy val SKOLEMIZE : Boolean = isSet(PARAM_SKOLEMIZE)
 
   lazy val RELEVANCE_FILTERING: Boolean = isSet(PARAM_RELEVANCEFILTER)
   lazy val RELEVANCE_PASSMARK: Double = uniqueDoubleFor(PARAM_PASSMARK, DEFAULT_PASSMARK)

--- a/src/main/scala/leo/Configuration.scala
+++ b/src/main/scala/leo/Configuration.scala
@@ -82,6 +82,7 @@ object Configuration extends DefaultConfiguration {
       // Force computation of lazy values for early error output
       PROBLEMFILE
       PROOF_OBJECT
+      LP_PROOF_OBJECT
       VERBOSITY
       LPDEBUG
       SOS

--- a/src/main/scala/leo/modules/Modes.scala
+++ b/src/main/scala/leo/modules/Modes.scala
@@ -8,11 +8,13 @@ import leo.modules.input.{Input, ProblemStatistics, TPTPParser}
 
 object Modes {
   final def apply(beginTime: Long, parsedProblem: Seq[AnnotatedFormula], stats: ProblemStatistics): Unit = {
-    val timeout = Configuration.TIMEOUT
+    lazy val timeout = Configuration.TIMEOUT
     if (Configuration.isSet("seq")) {
       seqLoop(beginTime, timeout, parsedProblem, stats)
     } else if (Configuration.isSet("scheduled")) {
       scheduledSeq(beginTime, timeout, parsedProblem)
+    } else if (Configuration.SKOLEMIZE) {
+      skolemize(parsedProblem)
     } else if (Configuration.isSet("processOnly")) {
       normalizationOnly(parsedProblem)
     } else if (Configuration.isSet("syntaxcheck")) {
@@ -75,6 +77,11 @@ object Modes {
   final def normalizationOnly(parsedProblem: Seq[AnnotatedFormula]): Unit = {
     Out.info("Running in processOnly mode.")
     modes.Normalization(parsedProblem)
+  }
+
+  final def skolemize(parsedProblem: Seq[AnnotatedFormula]): Unit = {
+    Out.info("Running in skolemize mode.")
+    modes.Skolemize(parsedProblem)
   }
 
   final def seqLoop(startTime: Long, timeout: Int, parsedProblem: Seq[AnnotatedFormula], stats: ProblemStatistics): Unit = {

--- a/src/main/scala/leo/modules/modes/Skolemize.scala
+++ b/src/main/scala/leo/modules/modes/Skolemize.scala
@@ -19,9 +19,15 @@ import leo.modules.output.LPoutput.NewLpDatastructures.{Arg, ClauseEncoding, Lev
   * the `require open` line for the Leo-specific proof libraries it uses, then
   * the Lambdapi proof payload between SZS start/end markers:
   *
-  *   - an `encodedProof (h : π F.lambdapi__negated_conjecture) : π target`
-  *     proof script;
-  *   - a final rewrite rule `rule F.target ↪ λ h, encodedProof h;`.
+  *   - an `encodedProof` proof script;
+  *   - a final rewrite rule for `F.target`.
+  *
+  * GDV has two proof-obligation shapes that matter here. In regular proofs,
+  * both the parent assumptions and the target conjecture are `π'` symbols. In
+  * leaf proofs, the parent assumptions are original problem formulae of type
+  * `π`, while the target conjecture is still a `π'` symbol. Until GDV passes
+  * that distinction explicitly, this module infers the scenario from GDV's
+  * current `_pN` suffix convention for problem formula symbols.
   *
   * The supported non-admitted proof shape is deliberately narrow. After the
   * outer universal prefix of the target has been assumed, the parent formula
@@ -46,6 +52,25 @@ object Skolemize {
   /** Which skolem rewrite lemma to use, or why this step has to be admitted. */
   private final case class SkolemRewritePlan(ruleName: String, admitReason: Option[String])
   private final val gdvNegatedConjectureName = "lambdapi__negated_conjecture"
+
+  private final def isGdvProblemFormulaName(name: String): Boolean =
+    name.matches(""".*_p[0-9]+$""")
+
+  /** Whether parent assumptions are `π` leaves or GDV-derived `π'` formulae. */
+  private sealed trait GdvProofScenario {
+    def parentProofsNeedNegatedConjecture: Boolean
+  }
+  private case object RegularGdvProof extends GdvProofScenario {
+    override val parentProofsNeedNegatedConjecture: Boolean = true
+  }
+  private case object LeafGdvProof extends GdvProofScenario {
+    override val parentProofsNeedNegatedConjecture: Boolean = false
+  }
+
+  private final def inferGdvProofScenario(obligation: SkolemizationObligation): GdvProofScenario = {
+    if (isGdvProblemFormulaName(obligation.parent.name)) LeafGdvProof
+    else RegularGdvProof
+  }
 
   /** A skolemization redex in the parent formula and the Lambdapi lemma that rewrites it. */
   private sealed trait SkolemRedexKind {
@@ -136,16 +161,20 @@ object Skolemize {
     // The target name is the GDV/Formulae.lp symbol name, not a Leo-internal proof
     // step name. GDV checks completion by seeing an uncommented `rule F.<name>`.
     val ro = RenderOptions(sigPrefix = true, formulaPrefix = true)
+    val proofScenario = inferGdvProofScenario(obligation)
     val encodedProofName = freshLocalName("encodedProof", processed.sig, targetPrefix.binders.map(_._1.value).toSet)
-    val proofData = skolemizationProofDefinition(obligation, parent, target, targetPrefix, parentPrefix, processed.sig, encodedProofName)
+    val proofData = skolemizationProofDefinition(obligation, parent, target, targetPrefix, parentPrefix, processed.sig, encodedProofName, proofScenario)
+    val encodedProofConst = LpTerm.Const[Level.Meta](SymRef.LP(QName.local(encodedProofName.value)))
+    val proofName = proofData.negatedConjectureProofName
+    val proofParam = LpTerm.Var[Level.Meta](proofName, None)
     val applyEncodedProof = LpTerm.App[Level.Meta](
-      LpTerm.Const[Level.Meta](SymRef.LP(QName.local(encodedProofName.value))),
-      Seq(Arg.Explicit[Level.Meta](LpTerm.Var[Level.Meta](proofData.negatedConjectureProofName, None)))
+      encodedProofConst,
+      Seq(Arg.Explicit[Level.Meta](proofParam))
     )
     val finalRule = Stmt.Rule(
       LpTerm.Const[Level.Meta](SymRef.LP(QName.in(Prefix.Formula, obligation.target.name))),
       Seq.empty,
-      LpTerm.Lam[Level.Meta](proofData.negatedConjectureProofName -> None, applyEncodedProof)
+      LpTerm.Lam[Level.Meta](proofName -> None, applyEncodedProof)
     )
 
     s"""$gdvRequireOpenLine
@@ -163,11 +192,13 @@ object Skolemize {
                                                  targetPrefix: ForallPrefix,
                                                  parentPrefix: ForallPrefix,
                                                  sig: LpSig,
-                                                 encodedProofName: Name): SkolemizationProofData = {
+                                                 encodedProofName: Name,
+                                                 proofScenario: GdvProofScenario): SkolemizationProofData = {
     val binderNames = targetPrefix.binders.map(_._1.value).toSet
     val negatedConjecture = freshLocalName("negatedConj", sig, binderNames + encodedProofName.value)
     val assumedNames = targetPrefix.binders.map(_._1)
-    val parentProofArgs = negatedConjecture +: assumedNames
+    val parentProofArgs =
+      (if (proofScenario.parentProofsNeedNegatedConjecture) Seq(negatedConjecture) else Seq.empty) ++ assumedNames
     val implication = LogicConst.Imp(parentPrefix.body, targetPrefix.body)
     val haveName = freshLocalName("SK_dev", sig, parentProofArgs.map(_.value).toSet + encodedProofName.value)
     val hName = freshLocalName("h", sig, parentProofArgs.map(_.value).toSet ++ Set(encodedProofName.value, haveName.value))
@@ -194,11 +225,13 @@ object Skolemize {
       rewritePlan.admitReason match {
         case Some(reason) =>
           Seq(
+            LpProofScript.Assume(Seq(negatedConjecture)),
             LpProofScript.Comment(reason),
             LpProofScript.Admit
           )
         case None =>
           Seq(
+            LpProofScript.Assume(Seq(negatedConjecture)),
             LpProofScript.Assume(assumedNames),
             haveStep,
             LpProofScript.Refine(applyHave),

--- a/src/main/scala/leo/modules/modes/Skolemize.scala
+++ b/src/main/scala/leo/modules/modes/Skolemize.scala
@@ -1,0 +1,459 @@
+package leo.modules.modes
+
+import leo.Configuration
+import leo.datastructures.{Role_Definition, Role_Type, Signature, TPTP, Term}
+import leo.datastructures.TPTP.AnnotatedFormula
+import leo.modules.{SZSException, SZSOutput, SZSResult, termToClause}
+import leo.modules.input.Input
+import leo.modules.output.{SZS_InputError, SZS_Proof, SZS_Success}
+import leo.Out
+import leo.modules.output.LPoutput.NewLpDatastructures.{Arg, ClauseEncoding, Level, LogicConst, LpProofScript, LpSig, LpTerm, LpType, Name, Prefix, QName, RenderOptions, Renderer, Stmt, SymRef}
+
+/**
+  * Experimental GDV mode for TPTP proof obligations that represent a single
+  * skolemization step.
+  *
+  * GDV still owns the Lambdapi package context: it prepends `require` commands
+  * for Signature.lp, Formulae.lp and parent proof files. This mode therefore
+  * only prints the Lambdapi payload between SZS start/end markers:
+  *
+  *   - an `encodedProof (h : π F.lambdapi__negated_conjecture) : π target`
+  *     proof script;
+  *   - a final rewrite rule `rule F.target ↪ λ h, encodedProof h;`.
+  *
+  * The supported non-admitted proof shape is deliberately narrow. After the
+  * outer universal prefix of the target has been assumed, the parent formula
+  * must expose the skolemization redex at the current proof goal level. If the
+  * redex is below another object-level binder, the current Lambdapi rewrite
+  * tactic cannot rewrite it, so this mode emits an admitted proof with an
+  * explanatory comment instead of generating a proof script that would fail.
+  */
+object Skolemize {
+  /** Data carried by GDV-style skolemization annotations. */
+  final case class SkolemizationInfo(status: String,
+                                     newSymbols: Seq[String],
+                                     variable: String,
+                                     term: String)
+  /** The conjecture to prove, the single parent formula it was derived from, and the annotation data. */
+  final case class SkolemizationObligation(target: AnnotatedFormula,
+                                           parent: AnnotatedFormula,
+                                           info: SkolemizationInfo)
+  private final case class ProcessedLpInput(sig: LpSig, formulas: Map[String, Term])
+  private final case class EncodedFormula(name: String, formula: LpTerm[Level.Obj])
+  private final case class ForallPrefix(binders: Seq[(Name, LpType)], body: LpTerm[Level.Obj])
+  /** Which skolem rewrite lemma to use, or why this step has to be admitted. */
+  private final case class SkolemRewritePlan(ruleName: String, admitReason: Option[String])
+  private final val gdvNegatedConjectureName = "lambdapi__negated_conjecture"
+
+  /** A skolemization redex in the parent formula and the Lambdapi lemma that rewrites it. */
+  private sealed trait SkolemRedexKind {
+    def ruleName: String
+  }
+  private case object ExistentialRedex extends SkolemRedexKind {
+    override val ruleName: String = "∃_skolem"
+  }
+  private case object NegatedUniversalRedex extends SkolemRedexKind {
+    override val ruleName: String = "∀_skolem"
+  }
+
+  /**
+    * Generate a local Lambdapi name that avoids the current LP signature and
+    * the names already introduced in this proof script.
+    *
+    * In GDV files the problem signature is normally imported as `S`, so a user
+    * symbol `h` would render as `S.h`. Still, avoiding those local names keeps
+    * the generated script robust against changes to the surrounding require
+    * block and against helper names that coincide with problem symbols.
+    */
+  private final def freshLocalName(base: String, sig: LpSig, occupied: Set[String]): Name = {
+    val unavailable = signatureLocalNames(sig) ++ occupied
+    @annotation.tailrec
+    def loop(index: Int): String = {
+      val candidate = if (index == 0) base else s"${base}_$index"
+      if (unavailable(candidate)) loop(index + 1) else candidate
+    }
+
+    Name(loop(0))
+  }
+
+  private final def signatureLocalNames(sig: LpSig): Set[String] = {
+    val signatureTermNames = sig.termNames.values.map(_.local.value)
+    val signatureTypeNames = sig.typeNames.values.map(_.local.value)
+    sig.reserved ++ signatureTermNames ++ signatureTypeNames ++ Set("S", "F")
+  }
+
+  final def apply(parsedProblem: Seq[AnnotatedFormula]): Unit = {
+    val obligations = extractSkolemizationObligations(parsedProblem)
+    val payload =
+      obligations match {
+        case Seq() =>
+          "No skolemization obligations found."
+        case Seq(obligation) =>
+          val processedLpInput = processLpInput(parsedProblem)
+          renderSkolemizationProof(obligation, processedLpInput)
+        case _ =>
+          throw new SZSException(SZS_InputError, s"Expected at most one skolemization obligation, found ${obligations.size}.")
+      }
+
+    Out.output(SZSResult(SZS_Success, Configuration.PROBLEMFILE, "Skolemization mode selected."))
+    Out.output(SZSOutput(SZS_Proof, Configuration.PROBLEMFILE, payload))
+  }
+
+  private final def processLpInput(parsedProblem: Seq[AnnotatedFormula]): ProcessedLpInput = {
+    implicit val sig: Signature = Signature.freshWithHOL()
+    parsedProblem.filter(_.role == Role_Type.pretty).foreach(Input.processFormula(_))
+    // Skolem definition formulae are not needed for the proof fragment generated
+    // here: the type declarations already register the skolem symbols used in the
+    // parent/target formulae. We therefore skip definitions in this mode instead of
+    // converting and storing them as ordinary proof formulae.
+    val processed = parsedProblem.filterNot(formula => formula.role == Role_Type.pretty || formula.role == Role_Definition.pretty).map { formula =>
+      val (_, term, role) = Input.processFormula(formula)
+      formula.name -> (term, role)
+    }
+    val formulaTerms = processed.collect {
+      case (name, (term, role)) if role != Role_Type && role != Role_Definition => name -> term
+    }.toMap
+    ProcessedLpInput(LpSig.fromLeo(sig), formulaTerms)
+  }
+
+  private final def encodeFormula(name: String, processed: ProcessedLpInput): EncodedFormula = {
+    val term = processed.formulas.getOrElse(name, {
+      throw new SZSException(SZS_InputError, s"Could not find processed formula '$name' for Lambdapi encoding.")
+    })
+    val encoded = ClauseEncoding.clause2LP(termToClause(term))
+    EncodedFormula(name, encoded.term)
+  }
+
+  private final def renderSkolemizationProof(obligation: SkolemizationObligation,
+                                             processed: ProcessedLpInput): String = {
+    val parent = encodeFormula(obligation.parent.name, processed)
+    val target = encodeFormula(obligation.target.name, processed)
+    val targetPrefix = stripLeadingForalls(target.formula)
+    val parentPrefix = stripForalls(parent.formula, targetPrefix.binders.size, parent.name)
+
+    // The target name is the GDV/Formulae.lp symbol name, not a Leo-internal proof
+    // step name. GDV checks completion by seeing an uncommented `rule F.<name>`.
+    val ro = RenderOptions(sigPrefix = true, formulaPrefix = true)
+    val encodedProofName = freshLocalName("encodedProof", processed.sig, targetPrefix.binders.map(_._1.value).toSet)
+    val proofData = skolemizationProofDefinition(obligation, parent, target, targetPrefix, parentPrefix, processed.sig, encodedProofName)
+    val applyEncodedProof = LpTerm.App[Level.Meta](
+      LpTerm.Const[Level.Meta](SymRef.LP(QName.local(encodedProofName.value))),
+      Seq(Arg.Explicit[Level.Meta](LpTerm.Var[Level.Meta](proofData.negatedConjectureProofName, None)))
+    )
+    val finalRule = Stmt.Rule(
+      LpTerm.Const[Level.Meta](SymRef.LP(QName.in(Prefix.Formula, obligation.target.name))),
+      Seq.empty,
+      LpTerm.Lam[Level.Meta](proofData.negatedConjectureProofName -> None, applyEncodedProof)
+    )
+
+    s"""${Renderer.stmt(proofData.definition, processed.sig, ro).trim}
+       |
+       |${Renderer.stmt(finalRule, processed.sig, ro).trim}""".stripMargin
+  }
+
+  private final case class SkolemizationProofData(definition: Stmt.Definition, negatedConjectureProofName: Name)
+
+  private final def skolemizationProofDefinition(obligation: SkolemizationObligation,
+                                                 parent: EncodedFormula,
+                                                 target: EncodedFormula,
+                                                 targetPrefix: ForallPrefix,
+                                                 parentPrefix: ForallPrefix,
+                                                 sig: LpSig,
+                                                 encodedProofName: Name): SkolemizationProofData = {
+    val binderNames = targetPrefix.binders.map(_._1.value).toSet
+    val negatedConjecture = freshLocalName("negatedConj", sig, binderNames + encodedProofName.value)
+    val assumedNames = targetPrefix.binders.map(_._1)
+    val parentProofArgs = negatedConjecture +: assumedNames
+    val implication = LogicConst.Imp(parentPrefix.body, targetPrefix.body)
+    val haveName = freshLocalName("SK_dev", sig, parentProofArgs.map(_.value).toSet + encodedProofName.value)
+    val hName = freshLocalName("h", sig, parentProofArgs.map(_.value).toSet ++ Set(encodedProofName.value, haveName.value))
+    val rewritePlan = skolemRewritePlan(obligation, targetPrefix.binders.size)
+
+    val skolemRewrite = LpTerm.Const[Level.Meta](SymRef.LP(QName.local(rewritePlan.ruleName)))
+    val haveStep = LpProofScript.Have(
+      haveName,
+      LpType.Prf(implication),
+      Seq(
+        Left(LpProofScript.Rewrite(None, skolemRewrite)),
+        Left(LpProofScript.Simplify()),
+        Left(LpProofScript.Assume(Seq(hName))),
+        Left(LpProofScript.Refine(LpTerm.Var[Level.Meta](hName, None)))
+      )
+    )
+
+    val applyHave = LpTerm.App[Level.Meta](
+      LpTerm.Const[Level.Meta](SymRef.LP(QName.local(haveName.value))),
+      Seq(Arg.Explicit[Level.Meta](LpTerm.Wildcard[Level.Meta]()))
+    )
+    val applyParent = formulaProofApplication(parent.name, parentProofArgs)
+    val proofScript =
+      rewritePlan.admitReason match {
+        case Some(reason) =>
+          Seq(
+            LpProofScript.Comment(reason),
+            LpProofScript.Admit
+          )
+        case None =>
+          Seq(
+            LpProofScript.Assume(assumedNames),
+            haveStep,
+            LpProofScript.Refine(applyHave),
+            LpProofScript.Refine(applyParent)
+          )
+      }
+
+    SkolemizationProofData(
+      Stmt.Definition(
+        encodedProofName,
+        Seq(
+          negatedConjecture -> LpType.Prf(
+            LpTerm.Const[Level.Obj](SymRef.LP(QName.in(Prefix.Formula, gdvNegatedConjectureName)))
+          )
+        ),
+        Some(LpType.Prf(target.formula)),
+        Stmt.DefBody.ProofBody(proofScript)
+      ),
+      negatedConjecture
+    )
+  }
+
+  private final def formulaProofApplication(formulaName: String, args: Seq[Name]): LpTerm[Level.Meta] = {
+    val head = LpTerm.Const[Level.Meta](SymRef.LP(QName.in(Prefix.Formula, formulaName)))
+    if (args.isEmpty) head
+    else {
+      LpTerm.App[Level.Meta](head, args.map(name => Arg.Explicit[Level.Meta](LpTerm.Var[Level.Meta](name, None))))
+    }
+  }
+
+  private final def stripLeadingForalls(formula: LpTerm[Level.Obj]): ForallPrefix = {
+    @annotation.tailrec
+    def loop(rest: LpTerm[Level.Obj], binders: Seq[(Name, LpType)]): ForallPrefix = rest match {
+      case LogicConst.Forall(binder, body) => loop(body, binders :+ binder)
+      case _ => ForallPrefix(binders, rest)
+    }
+
+    loop(formula, Seq.empty)
+  }
+
+  private final def stripForalls(formula: LpTerm[Level.Obj], count: Int, formulaName: String): ForallPrefix = {
+    @annotation.tailrec
+    def loop(rest: LpTerm[Level.Obj], remaining: Int, binders: Seq[(Name, LpType)]): ForallPrefix = {
+      if (remaining == 0) ForallPrefix(binders, rest)
+      else rest match {
+        case LogicConst.Forall(binder, body) => loop(body, remaining - 1, binders :+ binder)
+        case _ => throw new SZSException(SZS_InputError, s"Expected formula '$formulaName' to have at least $count leading universal quantifier(s).")
+      }
+    }
+
+    loop(formula, count, Seq.empty)
+  }
+
+  private final def skolemRewritePlan(obligation: SkolemizationObligation,
+                                      strippedOuterUniversals: Int): SkolemRewritePlan = {
+    // Use the source formula when possible: the skolemization annotation names
+    // the variable whose binding quantifier is rewritten. This avoids guessing
+    // the redex from the closest existential; provers are not required to
+    // skolemize from outside to inside.
+    val skolemizedVariable = obligation.info.variable
+    obligation.parent match {
+      case TPTP.TFFAnnotated(_, _, TPTP.TFF.Logical(formula), _) =>
+        val stripped = stripTFFLeadingUniversals(formula, strippedOuterUniversals)
+        planFromLocatedRedex(tffSkolemRedexDepth(stripped, skolemizedVariable), skolemizedVariable)
+      case TPTP.FOFAnnotated(_, _, TPTP.FOF.Logical(formula), _) =>
+        val stripped = stripFOFLeadingUniversals(formula, strippedOuterUniversals)
+        planFromLocatedRedex(fofSkolemRedexDepth(stripped, skolemizedVariable), skolemizedVariable)
+      case _ =>
+        SkolemRewritePlan(
+          ExistentialRedex.ruleName,
+          Some(s"Cannot verify skolemization: parent formula format does not expose source quantifiers for skolemized variable '$skolemizedVariable'")
+        )
+    }
+  }
+
+  private final def planFromLocatedRedex(redex: Option[(SkolemRedexKind, Int)],
+                                         skolemizedVariable: String): SkolemRewritePlan = {
+    redex match {
+      case Some((kind, 0)) =>
+        SkolemRewritePlan(kind.ruleName, None)
+      case Some((kind, _)) =>
+        SkolemRewritePlan(
+          kind.ruleName,
+          Some("Cannot verify skolemization: the skolemization redex occurs under a binder, and the Lambdapi rewrite tactic cannot rewrite under binders here"))
+      case None =>
+        SkolemRewritePlan(
+          ExistentialRedex.ruleName,
+          Some(s"Cannot verify skolemization: could not find a quantifier binding skolemized variable '$skolemizedVariable' in the parent formula"))
+    }
+  }
+
+  private final def stripTFFLeadingUniversals(formula: TPTP.TFF.Formula, count: Int): TPTP.TFF.Formula = {
+    @annotation.tailrec
+    def loop(current: TPTP.TFF.Formula, remaining: Int): TPTP.TFF.Formula = {
+      if (remaining <= 0) current
+      else current match {
+        case TPTP.TFF.QuantifiedFormula(TPTP.TFF.!, variableList, body) =>
+          val (_, keptVariables) = variableList.splitAt(remaining)
+          if (keptVariables.isEmpty) loop(body, remaining - variableList.size)
+          else TPTP.TFF.QuantifiedFormula(TPTP.TFF.!, keptVariables, body)
+        case _ => current
+      }
+    }
+
+    loop(formula, count)
+  }
+
+  private final def stripFOFLeadingUniversals(formula: TPTP.FOF.Formula, count: Int): TPTP.FOF.Formula = {
+    @annotation.tailrec
+    def loop(current: TPTP.FOF.Formula, remaining: Int): TPTP.FOF.Formula = {
+      if (remaining <= 0) current
+      else current match {
+        case TPTP.FOF.QuantifiedFormula(TPTP.FOF.!, variableList, body) =>
+          val (_, keptVariables) = variableList.splitAt(remaining)
+          if (keptVariables.isEmpty) loop(body, remaining - variableList.size)
+          else TPTP.FOF.QuantifiedFormula(TPTP.FOF.!, keptVariables, body)
+        case _ => current
+      }
+    }
+
+    loop(formula, count)
+  }
+
+  private final def tffSkolemRedexDepth(formula: TPTP.TFF.Formula, skolemizedVariable: String): Option[(SkolemRedexKind, Int)] = {
+    def minDepth(depths: Option[(SkolemRedexKind, Int)]*): Option[(SkolemRedexKind, Int)] = depths.flatten.minByOption(_._2)
+
+    def variableNames(vars: Seq[(String, Option[TPTP.TFF.Type])]): Seq[String] = vars.map(_._1)
+
+    def loop(current: TPTP.TFF.Formula, binderDepth: Int, negated: Boolean): Option[(SkolemRedexKind, Int)] = current match {
+      case TPTP.TFF.QuantifiedFormula(TPTP.TFF.?, variableList, _) if variableNames(variableList).contains(skolemizedVariable) =>
+        Some(ExistentialRedex -> binderDepth)
+      case TPTP.TFF.QuantifiedFormula(TPTP.TFF.!, variableList, _) if negated && variableNames(variableList).contains(skolemizedVariable) =>
+        Some(NegatedUniversalRedex -> binderDepth)
+      case TPTP.TFF.QuantifiedFormula(_, _, body) =>
+        loop(body, binderDepth + 1, negated = false)
+      case TPTP.TFF.UnaryFormula(TPTP.TFF.~, body) =>
+        loop(body, binderDepth, !negated)
+      case TPTP.TFF.BinaryFormula(_, left, right) =>
+        minDepth(loop(left, binderDepth, negated = false), loop(right, binderDepth, negated = false))
+      case TPTP.TFF.ConditionalFormula(condition, _, _) =>
+        loop(condition, binderDepth, negated = false)
+      case _ => None
+    }
+
+    loop(formula, 0, negated = false)
+  }
+
+  private final def fofSkolemRedexDepth(formula: TPTP.FOF.Formula, skolemizedVariable: String): Option[(SkolemRedexKind, Int)] = {
+    def minDepth(depths: Option[(SkolemRedexKind, Int)]*): Option[(SkolemRedexKind, Int)] = depths.flatten.minByOption(_._2)
+
+    def loop(current: TPTP.FOF.Formula, binderDepth: Int, negated: Boolean): Option[(SkolemRedexKind, Int)] = current match {
+      case TPTP.FOF.QuantifiedFormula(TPTP.FOF.?, variableList, _) if variableList.contains(skolemizedVariable) =>
+        Some(ExistentialRedex -> binderDepth)
+      case TPTP.FOF.QuantifiedFormula(TPTP.FOF.!, variableList, _) if negated && variableList.contains(skolemizedVariable) =>
+        Some(NegatedUniversalRedex -> binderDepth)
+      case TPTP.FOF.QuantifiedFormula(_, _, body) =>
+        loop(body, binderDepth + 1, negated = false)
+      case TPTP.FOF.UnaryFormula(TPTP.FOF.~, body) =>
+        loop(body, binderDepth, !negated)
+      case TPTP.FOF.BinaryFormula(_, left, right) =>
+        minDepth(loop(left, binderDepth, negated = false), loop(right, binderDepth, negated = false))
+      case _ => None
+    }
+
+    loop(formula, 0, negated = false)
+  }
+
+  final def extractSkolemizationObligations(parsedProblem: Seq[AnnotatedFormula]): Seq[SkolemizationObligation] = {
+    val formulaByName = parsedProblem.map(formula => formula.name -> formula).toMap
+    // Per GDV invocation, the current proof obligation is the conjecture. Older
+    // skolemization steps may be present as axioms in the same `.p` file; those
+    // annotations intentionally do not create obligations here.
+    parsedProblem.filter(_.role == "conjecture").flatMap { formula =>
+      parseSkolemizationAnnotation(formula.annotations).map { case (info, parentNames) =>
+        val parentName = parentNames match {
+          case Seq(singleParent) => singleParent
+          case _ => throw new SZSException(SZS_InputError, s"Expected exactly one skolemization parent for '${formula.name}', found ${parentNames.size}.")
+        }
+        val parent = formulaByName.getOrElse(parentName, {
+          throw new SZSException(SZS_InputError, s"Skolemization parent '$parentName' referenced by '${formula.name}' is not present in the problem.")
+        })
+        SkolemizationObligation(formula, parent, info)
+      }
+    }
+  }
+
+  private final def parseSkolemizationAnnotation(annotation: TPTP.Annotations): Option[(SkolemizationInfo, Seq[String])] = {
+    annotation match {
+      case Some((source, _)) => source.data match {
+        case Seq(TPTP.MetaFunctionData("inference", Seq(SimpleMetaTerm(ruleName), GeneralList(infoTerms), GeneralList(parentTerms))))
+          if ruleName == "skolemize" || ruleName == "skolemization" =>
+          val info = parseSkolemizationInfo(infoTerms)
+          val parents = parentTerms.flatMap(simpleMetaName)
+          Some(info -> parents)
+        case _ => None
+      }
+      case None => None
+    }
+  }
+
+  private final def parseSkolemizationInfo(infoTerms: Seq[TPTP.GeneralTerm]): SkolemizationInfo = {
+    var status: Option[String] = None
+    var newSymbols: Option[Seq[String]] = None
+    var variable: Option[String] = None
+    var term: Option[String] = None
+
+    infoTerms.foreach {
+      case TPTP.GeneralTerm(Seq(TPTP.MetaFunctionData("status", Seq(SimpleMetaTerm(statusName)))), None) =>
+        status = setOnce("status", status, statusName)
+      case TPTP.GeneralTerm(Seq(TPTP.MetaFunctionData("new_symbols", Seq(SimpleMetaTerm("skolem"), GeneralList(symbolTerms)))), None) =>
+        newSymbols = setOnce("new_symbols(skolem, ...)", newSymbols, symbolTerms.flatMap(simpleMetaName))
+      case TPTP.GeneralTerm(Seq(TPTP.MetaFunctionData("skolemize", Seq(skolemVariable, skolemTerm))), None) =>
+        variable = setOnce("skolemize variable", variable, simpleName(skolemVariable).getOrElse {
+          throw new SZSException(SZS_InputError, s"Could not parse skolemized variable from annotation term '${skolemVariable.pretty}'.")
+        })
+        term = setOnce("skolemize term", term, skolemTerm.pretty)
+      case _ =>
+    }
+
+    SkolemizationInfo(
+      requireOne("status", status),
+      requireOne("new_symbols(skolem, ...)", newSymbols),
+      requireOne("skolemize variable", variable),
+      requireOne("skolemize term", term)
+    )
+  }
+
+  private final def setOnce[A](fieldName: String, previous: Option[A], next: A): Option[A] = previous match {
+    case None => Some(next)
+    case Some(_) => throw new SZSException(SZS_InputError, s"Duplicate $fieldName entry in skolemization annotation.")
+  }
+
+  private final def requireOne[A](fieldName: String, value: Option[A]): A = value match {
+    case Some(result) => result
+    case None => throw new SZSException(SZS_InputError, s"Missing $fieldName entry in skolemization annotation.")
+  }
+
+  private final def simpleMetaName(term: TPTP.GeneralTerm): Option[String] = term match {
+    case SimpleMetaTerm(name) => Some(name)
+    case _ => None
+  }
+
+  private final def simpleName(term: TPTP.GeneralTerm): Option[String] = term match {
+    case SimpleMetaTerm(name) => Some(name)
+    case TPTP.GeneralTerm(Seq(TPTP.MetaVariable(name)), None) => Some(name)
+    case _ => None
+  }
+
+  private object SimpleMetaTerm {
+    def unapply(term: TPTP.GeneralTerm): Option[String] = term match {
+      case TPTP.GeneralTerm(Seq(TPTP.MetaFunctionData(name, Seq())), None) => Some(name)
+      case _ => None
+    }
+  }
+
+  private object GeneralList {
+    def unapply(term: TPTP.GeneralTerm): Option[Seq[TPTP.GeneralTerm]] = term match {
+      case TPTP.GeneralTerm(Seq(), Some(terms)) => Some(terms)
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/leo/modules/modes/Skolemize.scala
+++ b/src/main/scala/leo/modules/modes/Skolemize.scala
@@ -7,15 +7,17 @@ import leo.modules.{SZSException, SZSOutput, SZSResult, termToClause}
 import leo.modules.input.Input
 import leo.modules.output.{SZS_InputError, SZS_Proof, SZS_Success}
 import leo.Out
+import leo.modules.output.LPoutput.LPoutput.gdvRequireOpenLine
 import leo.modules.output.LPoutput.NewLpDatastructures.{Arg, ClauseEncoding, Level, LogicConst, LpProofScript, LpSig, LpTerm, LpType, Name, Prefix, QName, RenderOptions, Renderer, Stmt, SymRef}
 
 /**
   * Experimental GDV mode for TPTP proof obligations that represent a single
   * skolemization step.
   *
-  * GDV still owns the Lambdapi package context: it prepends `require` commands
-  * for Signature.lp, Formulae.lp and parent proof files. This mode therefore
-  * only prints the Lambdapi payload between SZS start/end markers:
+  * GDV still owns most of the Lambdapi package context: it prepends `require`
+  * commands for Signature.lp, Formulae.lp and parent proof files. Leo prints
+  * the `require open` line for the Leo-specific proof libraries it uses, then
+  * the Lambdapi proof payload between SZS start/end markers:
   *
   *   - an `encodedProof (h : π F.lambdapi__negated_conjecture) : π target`
   *     proof script;
@@ -146,7 +148,9 @@ object Skolemize {
       LpTerm.Lam[Level.Meta](proofData.negatedConjectureProofName -> None, applyEncodedProof)
     )
 
-    s"""${Renderer.stmt(proofData.definition, processed.sig, ro).trim}
+    s"""$gdvRequireOpenLine
+       |
+       |${Renderer.stmt(proofData.definition, processed.sig, ro).trim}
        |
        |${Renderer.stmt(finalRule, processed.sig, ro).trim}""".stripMargin
   }

--- a/src/main/scala/leo/modules/modes/Skolemize.scala
+++ b/src/main/scala/leo/modules/modes/Skolemize.scala
@@ -230,9 +230,8 @@ object Skolemize {
             LpProofScript.Admit
           )
         case None =>
-          Seq(
-            LpProofScript.Assume(Seq(negatedConjecture)),
-            LpProofScript.Assume(assumedNames),
+          val maybeAssume = if (assumedNames.nonEmpty) Seq(LpProofScript.Assume(assumedNames)) else Seq.empty
+          (LpProofScript.Assume(Seq(negatedConjecture)) +: maybeAssume) ++ Seq(
             haveStep,
             LpProofScript.Refine(applyHave),
             LpProofScript.Refine(applyParent)

--- a/src/main/scala/leo/modules/output/LPoutput/LPoutput.scala
+++ b/src/main/scala/leo/modules/output/LPoutput/LPoutput.scala
@@ -737,6 +737,7 @@ object LPoutput {
     proofSteps = LpProofScript.Assume(Seq(conjName.local)) +: proofSteps
     val refineStep = LpProofScript.Refine(LpTerm.App[Level.Meta](Obj(Terms.lpDne),Seq(Arg.Explicit(LpTerm.Obj(conjecture)),Arg.Explicit(Wildcard[Level.Meta]))))
     proofSteps = refineStep +: proofSteps
+    gdvProofParam.foreach { proofParamName => proofSteps = LpProofScript.Assume(Seq(Name(proofParamName))) +: proofSteps}
     // finally, test if the derived last clause is the empty clause or a flex-flex clause.
     // Instanciate with the empty clause or introduce an additional step in case of a flex-flex clause
     val emptyClause = NewLpDatastructures.lpClauseInst(Seq(),Seq()).asMl//lpClause(Seq(), Seq(lpOlBot))

--- a/src/main/scala/leo/modules/output/LPoutput/LPoutput.scala
+++ b/src/main/scala/leo/modules/output/LPoutput/LPoutput.scala
@@ -57,6 +57,8 @@ object LPoutput {
   val permLibStr: String = f"${nameLeoIIILPlib}.${permlibFile}"
   val simpTacLibStr = f"${nameLeoIIILPlib}.${leoSimpTacticFile}"
   val calcRuleLibStr = f"${nameLeoIIILPlib}.${calcRuleLibFile}"
+  val gdvRequireOpenLine: String =
+    s"require open $calcRuleLibStr $permLibStr $simpTacLibStr Stdlib.Epsilon Stdlib.Disj Stdlib.Conj;"
 
   final class lpProofObject {
     var etaExpFlag: Boolean = true
@@ -885,6 +887,7 @@ object LPoutput {
   def proof2GDVLP(state: LocalState): String = {
     val targetFormulaName = gdvTargetNameFromState(state)
     val (proofFileSB,_,_) = extractNecessaryFormulas(state, true, Some(gdvNegatedConjectureProofName))
+    proofFileSB.insert(0, s"$gdvRequireOpenLine\n")
 
     val sig = LpSig.fromLeo(state.signature)
     val proofParam = LpTerm.Var[Level.Meta](Name(gdvNegatedConjectureProofName), None)

--- a/src/main/scala/leo/modules/output/LPoutput/LPoutput.scala
+++ b/src/main/scala/leo/modules/output/LPoutput/LPoutput.scala
@@ -2,7 +2,7 @@ package leo.modules.output.LPoutput
 
 import leo.{Out, modules}
 import leo.datastructures.Term.Integer
-import leo.datastructures.{ClauseProxy, Role_Axiom, Role_Conjecture, Role_NegConjecture, Signature, isPropSet}
+import leo.datastructures.{ClauseAnnotation, ClauseProxy, Role_Axiom, Role_Conjecture, Role_NegConjecture, Signature, isPropSet}
 import leo.modules.HOLSignature.{HOLDifference, HOLGreater, HOLGreaterEq, HOLLess, HOLLessEq, HOLProduct, HOLQuotient, HOLSum, HOLUnaryMinus}
 import leo.modules.output.LPoutput.DetUniSimpEncoding.encodeDetUniSimp
 import leo.modules.output.LPoutput.LpLibs.ND.Terms
@@ -497,6 +497,24 @@ object LPoutput {
     }
   }
 
+  private final val gdvNegatedConjectureProofName = "__negated_conjecture_proof__"
+  private final val gdvNegatedConjectureName = "lambdapi__negated_conjecture"
+
+  private def tptpFormulaNameFromAnnotation(annotation: ClauseAnnotation): String = {
+    val pretty = annotation.pretty
+    if (pretty == "introduced(axiom_of_choice)") "axiom_of_choice"
+    else pretty.dropRight(1).split(",", 2)(1)
+  }
+
+  private def isGdvProblemFormulaName(name: String): Boolean =
+    name.matches(""".*_p[0-9]+$""")
+
+  private def isGdvDerivedFormulaName(name: String): Boolean =
+    !isGdvProblemFormulaName(name) && !name.startsWith("lambdapi__")
+
+  private def gdvTargetNameFromState(state: LocalState): String =
+    lpEscapeName(tptpFormulaNameFromAnnotation(state.conjecture.annotation), state.signature, false)
+
   def generateObjectDeclaartions(proof: modules.Proof, sig: LpSig): (StringBuilder, StringBuilder, StringBuilder, StringBuilder) = {
 
     // add symbols of the user defined TPTP problem signature if necessary
@@ -574,12 +592,14 @@ object LPoutput {
     (typeDecSB, skDecsSB, defSB, tacticSB)
   }
 
-  def extractNecessaryFormulas(state: LocalState, gdv_mode: Boolean)  = {
+  def extractNecessaryFormulas(state: LocalState, gdv_mode: Boolean, gdvProofParam: Option[String] = None)  = {
+
 
     val proofFileSB: mutable.StringBuilder = new StringBuilder()
     val signatureFileSB: mutable.StringBuilder = new StringBuilder()
     val formulaeFileSB: mutable.StringBuilder = new StringBuilder()
     var proofSteps: Seq[LpProofScript] = Seq.empty
+    var gdvParentProofSteps: Seq[LpProofScript] = Seq.empty
 
     val flagSt = new lpProofObject
 
@@ -599,7 +619,7 @@ object LPoutput {
     val clausifiedSteps: mutable.HashMap[lpConstantTerm, lpConstantTerm] = mutable.HashMap.empty
     var conjEnc = false
     var axCounter = 0
-    val conjName = QName.local(s"negatedConjecture")
+    val conjName = QName.local(s"localNegatedConjecture")
 
     val problemEncSB: mutable.StringBuilder = new StringBuilder()
 
@@ -621,12 +641,24 @@ object LPoutput {
         }
       } else if (step.role == Role_Axiom) { //todo: what about other roles like lamme etc. ?
         val encClause = ClauseEncoding.clause2LP(step.cl)
-        val tptpName = step.annotation.pretty
-        val axName0 = if (tptpName == "introduced(axiom_of_choice)") "axiom_of_choice" else s"${tptpName.dropRight(1).split(",", 2)(1)}"
+        val axName0 = tptpFormulaNameFromAnnotation(step.annotation)
         val axName = if (gdv_mode) axName0 else axName0 + s"_p$axCounter"
         val safeAxName = lpEscapeName(axName,sig.orig,false)
         problemEncSB.append(NewLpDatastructures.Renderer.stmt(NewLpDatastructures.Stmt.Declaration(Name(safeAxName),Seq.empty,encClause.asMl),sig,RenderOptions(!outputSingleFile,false,monomorphic)))
-        identicalSteps += (stepId -> QName.in(Prefix.Formula, safeAxName))
+        gdvProofParam match {
+          case Some(proofParamName) =>
+            // If we are in GDV mode, and if the referenced formula is a derived formula from GDV earlier in the proof,
+            // define a new symbol for the version of the formula to which the negated conjecture of the global problem is applied.
+            val localName = s"gdv_parent_$safeAxName"
+            val formulaProof = LpTerm.Const[Level.Meta](SymRef.LP(QName.in(Prefix.Formula, safeAxName)))
+            val parentProof = if (isGdvDerivedFormulaName(safeAxName)) {
+                LpTerm.App[Level.Meta](formulaProof, Seq(Arg.Explicit[Level.Meta](LpTerm.Var[Level.Meta](Name(proofParamName), None))))
+              } else formulaProof
+            gdvParentProofSteps = gdvParentProofSteps :+ LpProofScript.Have(Name(localName), encClause.asMl, Seq(Left(LpProofScript.Refine(parentProof))))
+            identicalSteps += (stepId -> QName.local(localName))
+          case None =>
+            identicalSteps += (stepId -> QName.in(Prefix.Formula, safeAxName))
+        }
         Out.lp_debug_info(s"linking to axiom $safeAxName (id: $stepId)")
         axCounter = axCounter + 1
       } else {
@@ -635,7 +667,11 @@ object LPoutput {
         clausifiedSteps ++= newInfo.clausifiedSteps
         identicalSteps ++= newInfo.identicalSteps
         additionalSymbols = additionalSymbols ++ newInfo.additionalDefinedSymbols
-        val newStepsSeq = if (newProofSteps.isDefined) Seq(newProofSteps.get._1,newProofSteps.get._2) else Seq.empty
+        val newStepsSeq =
+          if (newProofSteps.isDefined) {
+            if (gdv_mode) Seq(newProofSteps.get._2)
+            else Seq(newProofSteps.get._1,newProofSteps.get._2)
+          } else Seq.empty
         proofSteps = proofSteps ++ newStepsSeq
       }
     }
@@ -697,6 +733,7 @@ object LPoutput {
 
     // construct the proof based on all the individual steps
     // in the proof of the conjecture, first instanciate dne, then assume the negated conjecture
+    proofSteps = gdvParentProofSteps ++ proofSteps
     proofSteps = LpProofScript.Assume(Seq(conjName.local)) +: proofSteps
     val refineStep = LpProofScript.Refine(LpTerm.App[Level.Meta](Obj(Terms.lpDne),Seq(Arg.Explicit(LpTerm.Obj(conjecture)),Arg.Explicit(Wildcard[Level.Meta]))))
     proofSteps = refineStep +: proofSteps
@@ -749,7 +786,10 @@ object LPoutput {
       Out.lp_debug_info(s"can encode: \n$encSt")
     }
      */
-    val completeProof = Stmt.Definition(Name("encodedProof"),Seq.empty,Some(LpType.Prf(conjecture)),Stmt.DefBody.ProofBody(proofSteps),Seq(),Seq(Opaque))
+    val gdvParams = gdvProofParam.toSeq.map { proofParamName =>
+      Name(proofParamName) -> LpType.Prf(LpTerm.Const[Level.Obj](SymRef.LP(QName.in(Prefix.Formula, gdvNegatedConjectureName))))
+    }
+    val completeProof = Stmt.Definition(Name("encodedProof"),gdvParams,Some(LpType.Prf(conjecture)),Stmt.DefBody.ProofBody(proofSteps),Seq(),Seq(Opaque))
     proofFileSB.append(Renderer.stmt(completeProof,sig,RenderOptions(!outputSingleFile,!outputSingleFile,monomorphic)))
 
     (proofFileSB,signatureFileSB,formulaeFileSB)
@@ -839,6 +879,18 @@ object LPoutput {
     val finalRule = lpRule(lpConstantTerm(s"$abbreviationFormulaeFile" + conjName), Seq.empty,lpConstantTerm(nameProofFile))
     proofFileSB.append("\n")
     proofFileSB.append(finalRule.pretty)
+    proofFileSB.toString()
+  }
+  def proof2GDVLP(state: LocalState): String = {
+    val targetFormulaName = gdvTargetNameFromState(state)
+    val (proofFileSB,_,_) = extractNecessaryFormulas(state, true, Some(gdvNegatedConjectureProofName))
+
+    val sig = LpSig.fromLeo(state.signature)
+    val proofParam = LpTerm.Var[Level.Meta](Name(gdvNegatedConjectureProofName), None)
+    val encodedProof = LpTerm.App[Level.Meta](LpTerm.Const[Level.Meta](SymRef.LP(QName.local(nameProofFile))), Seq(Arg.Explicit[Level.Meta](proofParam)))
+    val finalRule = Stmt.Rule(LpTerm.Const[Level.Meta](SymRef.LP(QName.in(Prefix.Formula, targetFormulaName))), Seq.empty, LpTerm.Lam[Level.Meta](Name(gdvNegatedConjectureProofName) -> None, encodedProof))
+    proofFileSB.append("\n")
+    proofFileSB.append(Renderer.stmt(finalRule, sig, RenderOptions(!outputSingleFile, !outputSingleFile, monomorphic)))
     proofFileSB.toString()
   }
 }

--- a/src/main/scala/leo/modules/prover/SeqLoop.scala
+++ b/src/main/scala/leo/modules/prover/SeqLoop.scala
@@ -494,7 +494,7 @@ object SeqLoop {
 
     if(Configuration.LP_PROOF_OBJECT && proof != null){
       try {
-        val proofString = proof2LP(state)
+        val proofString = proof2GDVLP(state)
         Out.output(SZSOutput(SZS_Refutation, Configuration.PROBLEMFILE, proofString))
       } catch {
         case e: Exception => Out.comment("Translation of proof object failed. See error logs for details.")


### PR DESCRIPTION
This PR adds GDV-oriented Lambdapi proof output for Leo-III proof obligations: 
- In `--gdv-lp` mode, Leo now prints a GDV-compatible Lambdapi scripts to stdout, including the Leo-specific require open line and a rewrite rule for the target `F.<formula>` symbol.
- It also introduces a new `--skolemize` mode for GDV skolemization proof obligations. This mode parses TSTP skolemization annotations, identifies the parent and target formulae, generates a Lambdapi proof for directly verifiable skolemization steps, and emits an admitted proof with an explanatory comment for cases that cannot currently be verified, such as redexes under binders. Note that in this mode we do not check the correctness of the Skolem step, we merely produce Lambdapi code under the assumption that all information given in the annotation as well as the underlying Skolemisazion are correct. For incorrect Skolem steps, Leo-III will not output an error message, but the generated scripts will be rejected by Lambdapi.